### PR TITLE
Add Expo starter app for Radio Revolution with background playback and low-data mode

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,0 +1,209 @@
+import { StatusBar } from 'expo-status-bar';
+import * as Linking from 'expo-linking';
+import { useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  Pressable,
+  SafeAreaView,
+  StyleSheet,
+  Text,
+  View
+} from 'react-native';
+import { STATION, type StreamQuality } from './src/config';
+import {
+  getPlaybackState,
+  initializePlayer,
+  pauseRadio,
+  playRadio,
+  switchQuality
+} from './src/player';
+
+const quickActions = [
+  { label: '💬 Chat with Host', url: STATION.chatUrl },
+  { label: '📝 Comment on Track', url: STATION.commentsUrl },
+  { label: '🎵 Song Request', url: STATION.requestUrl },
+  { label: '☕ Support / Buy Me a Coffee', url: STATION.supportUrl }
+];
+
+export default function App() {
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [quality, setQuality] = useState<StreamQuality>('low');
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const setup = async () => {
+      try {
+        await initializePlayer();
+        const state = await getPlaybackState();
+        setIsPlaying(state.state === 'playing' || state.state === 'buffering');
+      } catch {
+        Alert.alert('Playback Error', 'Could not initialize the player.');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    void setup();
+  }, []);
+
+  const togglePlayback = async () => {
+    try {
+      setLoading(true);
+      if (isPlaying) {
+        await pauseRadio();
+        setIsPlaying(false);
+        return;
+      }
+
+      await playRadio();
+      setIsPlaying(true);
+    } catch {
+      Alert.alert('Playback Error', 'Please verify your stream URL settings.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const changeQuality = async (nextQuality: StreamQuality) => {
+    if (nextQuality === quality) return;
+
+    try {
+      setLoading(true);
+      await switchQuality(nextQuality);
+      setQuality(nextQuality);
+      setIsPlaying(true);
+    } catch {
+      Alert.alert('Quality Switch Failed', 'Could not switch stream quality.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <SafeAreaView style={styles.screen}>
+      <StatusBar style="dark" />
+      <View style={styles.container}>
+        <Text style={styles.title}>{STATION.name}</Text>
+        <Text style={styles.subtitle}>{STATION.tagline}</Text>
+
+        <Pressable style={styles.playButton} onPress={togglePlayback}>
+          {loading ? (
+            <ActivityIndicator color="#ffffff" />
+          ) : (
+            <Text style={styles.playText}>{isPlaying ? 'Pause' : 'Play Live'}</Text>
+          )}
+        </Pressable>
+
+        <View style={styles.qualityRow}>
+          <Text style={styles.sectionLabel}>Data mode</Text>
+          <View style={styles.pillRow}>
+            <Pressable
+              style={[styles.pill, quality === 'low' && styles.pillActive]}
+              onPress={() => {
+                void changeQuality('low');
+              }}>
+              <Text style={styles.pillText}>Low Data</Text>
+            </Pressable>
+            <Pressable
+              style={[styles.pill, quality === 'high' && styles.pillActive]}
+              onPress={() => {
+                void changeQuality('high');
+              }}>
+              <Text style={styles.pillText}>High Quality</Text>
+            </Pressable>
+          </View>
+        </View>
+
+        <Text style={styles.sectionLabel}>Live actions</Text>
+        {quickActions.map((action) => (
+          <Pressable
+            key={action.label}
+            style={styles.actionButton}
+            onPress={() => {
+              void Linking.openURL(action.url);
+            }}>
+            <Text style={styles.actionText}>{action.label}</Text>
+          </Pressable>
+        ))}
+
+        <Text style={styles.helper}>
+          Optimized for low bandwidth first. Replace placeholder links in
+          src/config.ts with your real endpoints.
+        </Text>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: '#f9f9fb'
+  },
+  container: {
+    flex: 1,
+    gap: 14,
+    padding: 20
+  },
+  title: {
+    fontSize: 30,
+    fontWeight: '800'
+  },
+  subtitle: {
+    color: '#5b6170'
+  },
+  playButton: {
+    alignItems: 'center',
+    backgroundColor: '#18181b',
+    borderRadius: 16,
+    minHeight: 56,
+    justifyContent: 'center'
+  },
+  playText: {
+    color: '#ffffff',
+    fontSize: 20,
+    fontWeight: '700'
+  },
+  qualityRow: {
+    backgroundColor: '#ffffff',
+    borderRadius: 12,
+    padding: 12,
+    gap: 8
+  },
+  sectionLabel: {
+    color: '#2d3240',
+    fontSize: 15,
+    fontWeight: '700'
+  },
+  pillRow: {
+    flexDirection: 'row',
+    gap: 8
+  },
+  pill: {
+    backgroundColor: '#edf0f5',
+    borderRadius: 999,
+    paddingHorizontal: 12,
+    paddingVertical: 8
+  },
+  pillActive: {
+    backgroundColor: '#1f2937'
+  },
+  pillText: {
+    color: '#111827',
+    fontWeight: '600'
+  },
+  actionButton: {
+    backgroundColor: '#ffffff',
+    borderRadius: 12,
+    padding: 14
+  },
+  actionText: {
+    fontWeight: '600'
+  },
+  helper: {
+    color: '#6b7280',
+    fontSize: 12,
+    marginTop: 'auto'
+  }
+});

--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# Radio Revolution Mobile App (Starter)
+
+A production-ready starter for your internet radio app for Apple App Store and Google Play.
+
+## What is already built
+- One-tap **Play Live** button.
+- Background playback support (works with lock screen controls via `react-native-track-player`).
+- Default **Low Data** stream mode for listeners with expensive mobile data.
+- Switch to **High Quality** stream when users are on strong Wi‑Fi.
+- Quick action buttons for:
+  - Chat with host
+  - Track comments
+  - Song requests
+  - Support / Buy Me a Coffee
+
+## Configure your real links
+Update `src/config.ts` with your real URLs:
+- `streamUrls.low` (low bitrate stream for data saving)
+- `streamUrls.high` (high bitrate stream)
+- `chatUrl`, `commentsUrl`, `requestUrl`, `supportUrl`
+
+## Run locally
+```bash
+npm install
+npm run start
+```
+
+Then open iOS/Android simulator from Expo.
+
+## Suggested stream bitrates for Zimbabwe data-saving goals
+- **Low Data:** HE-AAC 24-32 kbps mono/stereo.
+- **High Quality:** AAC 64-128 kbps.
+
+This app defaults to Low Data mode to reduce data usage.

--- a/app.json
+++ b/app.json
@@ -1,0 +1,27 @@
+{
+  "expo": {
+    "name": "Radio Revolution",
+    "slug": "radio-revolution",
+    "version": "0.1.0",
+    "orientation": "portrait",
+    "userInterfaceStyle": "light",
+    "assetBundlePatterns": [
+      "**/*"
+    ],
+    "ios": {
+      "supportsTablet": true,
+      "bundleIdentifier": "com.radiorevolution.app",
+      "infoPlist": {
+        "UIBackgroundModes": [
+          "audio"
+        ]
+      }
+    },
+    "android": {
+      "package": "com.radiorevolution.app"
+    },
+    "plugins": [
+      "react-native-track-player"
+    ]
+  }
+}

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo']
+  };
+};

--- a/index.js
+++ b/index.js
@@ -1,0 +1,8 @@
+import { registerRootComponent } from 'expo';
+import TrackPlayer from 'react-native-track-player';
+import App from './App';
+import { playbackService } from './src/playbackService';
+
+TrackPlayer.registerPlaybackService(() => playbackService);
+
+registerRootComponent(App);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "radio-revolution-app",
+  "version": "0.1.0",
+  "private": true,
+  "main": "index.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "expo": "~52.0.0",
+    "expo-linking": "~7.0.0",
+    "expo-status-bar": "~2.0.0",
+    "react": "18.3.1",
+    "react-native": "0.76.1",
+    "react-native-track-player": "^4.1.1"
+  },
+  "devDependencies": {
+    "@types/react": "~18.3.12",
+    "typescript": "~5.6.3"
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,14 @@
+export const STATION = {
+  name: 'Radio Revolution',
+  tagline: 'Live from Zimbabwe',
+  streamUrls: {
+    low: 'https://example.com/radio-revolution-low.aac',
+    high: 'https://example.com/radio-revolution-high.aac'
+  },
+  supportUrl: 'https://buymeacoffee.com/radiorevolution',
+  requestUrl: 'https://example.com/song-request',
+  chatUrl: 'https://example.com/live-chat',
+  commentsUrl: 'https://example.com/track-comments'
+};
+
+export type StreamQuality = keyof typeof STATION.streamUrls;

--- a/src/playbackService.ts
+++ b/src/playbackService.ts
@@ -1,0 +1,15 @@
+import TrackPlayer, { Event } from 'react-native-track-player';
+
+export const playbackService = async () => {
+  TrackPlayer.addEventListener(Event.RemotePlay, () => {
+    TrackPlayer.play();
+  });
+
+  TrackPlayer.addEventListener(Event.RemotePause, () => {
+    TrackPlayer.pause();
+  });
+
+  TrackPlayer.addEventListener(Event.RemoteStop, () => {
+    TrackPlayer.stop();
+  });
+};

--- a/src/player.ts
+++ b/src/player.ts
@@ -1,0 +1,59 @@
+import TrackPlayer, {
+  AppKilledPlaybackBehavior,
+  Capability,
+  State,
+  type Track
+} from 'react-native-track-player';
+import { STATION, type StreamQuality } from './config';
+
+let initialized = false;
+
+const baseTrack = (quality: StreamQuality): Track => ({
+  id: `radio-revolution-${quality}`,
+  url: STATION.streamUrls[quality],
+  title: STATION.name,
+  artist: STATION.tagline,
+  artwork: undefined,
+  isLiveStream: true
+});
+
+export const initializePlayer = async () => {
+  if (initialized) return;
+
+  await TrackPlayer.setupPlayer();
+  await TrackPlayer.updateOptions({
+    capabilities: [Capability.Play, Capability.Pause, Capability.Stop],
+    compactCapabilities: [Capability.Play, Capability.Pause],
+    android: {
+      appKilledPlaybackBehavior:
+        AppKilledPlaybackBehavior.ContinuePlayback,
+      alwaysPauseOnInterruption: false
+    }
+  });
+
+  await TrackPlayer.add(baseTrack('low'));
+  initialized = true;
+};
+
+export const playRadio = async () => {
+  await initializePlayer();
+  await TrackPlayer.play();
+};
+
+export const pauseRadio = async () => {
+  await initializePlayer();
+  await TrackPlayer.pause();
+};
+
+export const switchQuality = async (quality: StreamQuality) => {
+  await initializePlayer();
+  const currentState = await TrackPlayer.getPlaybackState();
+  await TrackPlayer.reset();
+  await TrackPlayer.add(baseTrack(quality));
+
+  if (currentState.state === State.Playing || currentState.state === State.Buffering) {
+    await TrackPlayer.play();
+  }
+};
+
+export const getPlaybackState = () => TrackPlayer.getPlaybackState();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal, production-ready mobile starter so Radio Revolution can ship a standalone iOS/Android app with persistent live streaming and low-data defaults.
- Enable background/lock-screen playback, simple one-tap play, and quick interactive actions (chat, comments, requests, support) so live listeners can engage with the station.

### Description
- Bootstrapped an Expo + React Native TypeScript starter with `package.json`, `app.json`, `babel.config.js`, `tsconfig.json`, and `index.js` to register the app and playback service. 
- Implemented a clean main UI in `App.tsx` with a one-tap Play/Pause button, `Low Data` / `High Quality` stream toggle, and quick action buttons that open configured URLs.
- Added playback engine and background controls using `react-native-track-player` in `src/player.ts` (setup, play/pause/switch quality) and `src/playbackService.ts` (remote controls), and centralized station settings in `src/config.ts` with placeholder stream/chat/request/support URLs.
- Included `README.md` with run/config instructions and suggested low-bitrate targets for data-constrained listeners.

### Testing
- Ran `npm install`, which failed with a `403 Forbidden` from the npm registry so dependencies could not be fetched in this environment. (failed)
- Ran `npm run typecheck` (`tsc --noEmit`), which failed because required packages/types and `expo/tsconfig.base` were not available due to the blocked dependency install. (failed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d994c04dc832b96293bc400201096)